### PR TITLE
fix: Fix data parsing in the readStream handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -444,18 +444,20 @@ export class Conversation {
         let parsed;
         readStream(response, (a) => {
             rawResponse(a);
-            if (!a.toString().startsWith('data:')) {
-                return;
-            }
-            try {
-                parsed = JSON.parse(a.toString().replace(/^data\:/, '').split('\n\ndata:')[0]?.trim() || "{}");
-            } catch (e) {
-                return;
-            }
-            progress(parsed);
-            if (parsed.stop_reason === 'stop_sequence') {
-                done(parsed);
-                resolve(parsed);
+            const records = a.split('data:').map(record => record.trim()).filter(record => record.length > 0);
+            
+            for (const record of records) {
+                try {
+                    parsed = JSON.parse(record);
+                } catch (e) {
+                    continue;
+                }
+                progress(parsed);
+                if (parsed.stop_reason === 'stop_sequence') {
+                    done(parsed);
+                    resolve(parsed);
+                    return
+                }
             }
         })
         return returnPromise;


### PR DESCRIPTION

One raw response may contain multiple data records, such as

```
data: {"completion":"发","stop_reason":null,"model":"claude-2.0","stop":null,"log_id":"0f63900c7d9cb4e1ce0c2726aab96fdd2653acca07ecc01bd34add2fa0359a8e","messageLimit":{"type":"within_limit"}}

data: {"completion":"现","stop_reason":null,"model":"claude-2.0","stop":null,"log_id":"0f63900c7d9cb4e1ce0c2726aab96fdd2653acca07ecc01bd34add2fa0359a8e","messageLimit":{"type":"within_limit"}} 
```
This PR fixes the stream handler and supports those malformed response data.